### PR TITLE
Explicitly state login and password #39

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ If SSH keys are valid, it stores your private SSH key as an environment variable
 
 <br>
 
+## Logging into the Drupal UI Instance.
+
+1. Your username/password would be admin/admin.
+
 ## Notes
 
 * Manual SSH setup is a temporary requirement until the Drupal's self-hosted Gitlab gets integrated with Gitpod.


### PR DESCRIPTION
Issue #39  Readme update

# The Problem/Issue/Bug
The readme doesn't let users know the Drupal UI username and password.

## How this PR Solves The Problem
This PR adds extra login readme info.

## Manual Testing Instructions
The Drupal UI login info would be visible in the main readme.

## Related Issue Link(s)
Issue #1 

## Release/Deployment notes
This does not affect anything other than Readme.
