### PR TITLE
Issue #39 Updates helptext in vscode ext help.

### DIFF
--- a/src/vscode-extension/drupalpod-ext/src/help-content.ts
+++ b/src/vscode-extension/drupalpod-ext/src/help-content.ts
@@ -68,6 +68,10 @@ body {
               </ul>
             </li>
           </ol>
+          <ol class="list--ordered">
+            <li>To log in to Drupal: Use username/password = admin/admin
+          </ol>
+           
         </section>
 
         <section>


### PR DESCRIPTION
Issue #39 Updates helptext in vscode ext help.

# The Problem/Issue/Bug
The login info in the vscode helptext, shown while using DrupalPod / GitPod doesn't inform the user of the Drupal user login.

## How this PR Solves The Problem
Adds Help text.

## Manual Testing Instructions
See src/vscode-extension/drupalpod-ext/src/help-content.ts

## Related Issue Link(s)
Issue #1 

